### PR TITLE
Update model.py

### DIFF
--- a/model.py
+++ b/model.py
@@ -230,7 +230,7 @@ class PoseOptimizer(nn.Module):
         silhouette = silhouette.view(self.num_frames, self.num_hypos, h, w, c)
         
         # Calculate the silhouette loss
-        sil_loss, _ = losses.silhouette_loss(silhouette[..., 3], batch['mask_ref'].unsqueeze(1)) #torch.mean((image[..., 3] - batch['mask_ref'].unsqueeze(1)) ** 2, dim=(2, 3)).view(-1)
+        sil_loss, _ = losses.silhouette_loss(silhouette[..., 3], batch['mask_ref'].unsqueeze(1) + 1e-6) #torch.mean((image[..., 3] - batch['mask_ref'].unsqueeze(1)) ** 2, dim=(2, 3)).view(-1)
         sil_dice = losses.dice_loss(silhouette[:, 0, :, :, 3], batch['mask_ref'])
 
         # Calculate parts silhoette losses


### PR DESCRIPTION
## Fix: Prevent Division by Zero in Silhouette Loss Calculation  

### Issue  
The silhouette loss computation uses `batch['mask_ref']`. If `mask_ref` contains all zeros, it can cause a division by zero, leading to NaN values in the loss.  

### Fix  
Added a small epsilon (`1e-6`) to the denominator to prevent division by zero errors.  

### Changes Made  
- Updated the silhouette loss computation by adding `1e-6` to avoid NaN values.  
- Ensured stability in loss calculations.  

### Code Fix  
```python
# Before (prone to division by zero)
sil_loss, _ = losses.silhouette_loss(silhouette[..., 3], batch['mask_ref'].unsqueeze(1))

# After (with epsilon to prevent NaN)
sil_loss, _ = losses.silhouette_loss(silhouette[..., 3], batch['mask_ref'].unsqueeze(1) + 1e-6)
